### PR TITLE
Bugfix: busy loop in lda+u parser

### DIFF
--- a/dft_parser/pwscf/stdout_parser.py
+++ b/dft_parser/pwscf/stdout_parser.py
@@ -43,7 +43,7 @@ def _parse_pseudopotential(line, lines):
      return {'pseudopotential file': newline.split()[0]}
 
 def _parse_ldau(line, lines):
-    result = {'LDA+U l_max': line.split()[5].rstrip(")"), 'LDA+U parameters': {}}
+    result = {'LDA+U l_max': int(line.split()[5].rstrip(")")), 'LDA+U parameters': {}}
     next(lines)
     newline = next(lines).split()
     while len(newline) > 1:
@@ -54,6 +54,7 @@ def _parse_ldau(line, lines):
             'J0': float(newline[4]),
             'beta': float(newline[5])
         }
+        newline = next(lines).split()
     return result
 
 def _parse_bravais_lattice(line, lines):

--- a/dft_parser/pwscf/tests/test_stdout_parser.py
+++ b/dft_parser/pwscf/tests/test_stdout_parser.py
@@ -130,3 +130,23 @@ def test_parse_force_short():
     assert flattened["total SCF correction"] == 0.000014
     assert flattened["forces"][3][0] == -0.00137999
     assert flattened["Atomic species index for forces"][3] == 1
+
+
+def test_ldaU():
+    """Test parsing simplified LDA+U calculations"""
+    lines = """
+        Simplified LDA+U calculation (l_max = 2) with parameters (eV):
+        atomic species    L          U    alpha       J0     beta
+           Fe1            2     4.3000   0.0000   0.0000   0.0000
+           Fe2            2     4.3000   0.0000   0.0000   0.0000
+    """.split("\n")
+    parser = PwscfStdOutputParser()
+    results = list(parser.parse(lines))
+    flattened = {}
+    for r in results:
+        flattened.update(r)
+    assert flattened["LDA+U l_max"] == 2
+    assert flattened["LDA+U parameters"]["Fe1"]["L"] == 2
+    assert flattened["LDA+U parameters"]["Fe1"]["U"] == 4.3
+    assert flattened["LDA+U parameters"]["Fe2"]["L"] == 2
+    assert flattened["LDA+U parameters"]["Fe2"]["U"] == 4.3


### PR DESCRIPTION
Was missing a next() call